### PR TITLE
Pulling thakyZ/Avali to Fevix/Avali

### DIFF
--- a/objects/avaligeneric/doors/avalidarkverticaldoor.object
+++ b/objects/avaligeneric/doors/avalidarkverticaldoor.object
@@ -41,7 +41,7 @@
       "flipImages" : true,
       "direction" : "left",
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.01,
       "anchors" : [ "left", "right" ]
     },
     {
@@ -50,7 +50,7 @@
       "animationPosition" : [-16, 0],
       "direction" : "right",
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.01,
       "anchors" : [ "left", "right" ]
     }
   ],


### PR DESCRIPTION
- Fixed the Avali dark vertical door from dropping when on the last block down.