### PR TITLE
Pistol & Shotgun damage adjustments

### DIFF
--- a/items/guns/tier1/avalitier1minigun.gun
+++ b/items/guns/tier1/avalitier1minigun.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier1minigun",
   "inventoryIcon" : "avaliminigun.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The primary Avali suppressive fire and support weapon.",
   "shortdescription" : "MG1 Hailstorm",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 1.0,
-	"speed" : 70,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier1/avalitier1pistol.gun
+++ b/items/guns/tier1/avalitier1pistol.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier1pistol",
   "inventoryIcon" : "avalipistol.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The basic Avali military grade sidearm.",
   "shortdescription" : "PD1 Frostbite",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -18,8 +18,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 2.4,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier1/avalitier1rifle.gun
+++ b/items/guns/tier1/avalitier1rifle.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier1rifle",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR1 Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier1/avalitier1riflebounce.gun
+++ b/items/guns/tier1/avalitier1riflebounce.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier1riflebounce",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR1-R Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgunbnc",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 60,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier1/avalitier1rifleexplosive.gun
+++ b/items/guns/tier1/avalitier1rifleexplosive.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier1rifleexplosive",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR1-HE Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgunexp",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier1/avalitier1shotgun.gun
+++ b/items/guns/tier1/avalitier1shotgun.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalishotgun.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "common",
   "description" : "An avali shotgun!",
   "shortdescription" : "QRC Type-1",
   "image" : "avalishotgun.png",
@@ -21,8 +21,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 1.7,
+	"speed" : 150,
 	"life" : 3,
     "color" : [10, 255, 10]
   },

--- a/items/guns/tier1/avalitier1sniper.gun
+++ b/items/guns/tier1/avalitier1sniper.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalisniper.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "tooltipKind" : "bow",
   "weaponType" : "Bow",
   "description" : "An anti-materiel rifle more frequently used for hunting armoured vehicles than wildlife.",

--- a/items/guns/tier2/avalitier2minigun.gun
+++ b/items/guns/tier2/avalitier2minigun.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier2minigun",
   "inventoryIcon" : "avaliminigun.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The primary Avali suppressive fire and support weapon.",
   "shortdescription" : "MG2 Hailstorm",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 1.0,
-	"speed" : 70,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier2/avalitier2pistol.gun
+++ b/items/guns/tier2/avalitier2pistol.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier2pistol",
   "inventoryIcon" : "avalipistol.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The basic Avali military grade sidearm.",
   "shortdescription" : "PD2 Frostbite",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -18,8 +18,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 2.4,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier2/avalitier2rifle.gun
+++ b/items/guns/tier2/avalitier2rifle.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier2rifle",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR2 Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier2/avalitier2riflebounce.gun
+++ b/items/guns/tier2/avalitier2riflebounce.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier2riflebounce",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR2-R Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgunbnc",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 60,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier2/avalitier2rifleexplosive.gun
+++ b/items/guns/tier2/avalitier2rifleexplosive.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier2rifleexplosive",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR2-HE Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgunexp",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier2/avalitier2shotgun.gun
+++ b/items/guns/tier2/avalitier2shotgun.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalishotgun.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "common",
   "description" : "An avali shotgun!",
   "shortdescription" : "QRC Type-2",
   "image" : "avalishotgun.png",
@@ -21,8 +21,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 1.7,
+	"speed" : 150,
 	"life" : 3,
     "color" : [10, 255, 10]
   },

--- a/items/guns/tier2/avalitier2sniper.gun
+++ b/items/guns/tier2/avalitier2sniper.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalisniper.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "common",
   "tooltipKind" : "bow",
   "weaponType" : "Bow",
   "description" : "An anti-materiel rifle more frequently used for hunting armoured vehicles than wildlife.",

--- a/items/guns/tier3/avalitier3minigun.gun
+++ b/items/guns/tier3/avalitier3minigun.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier3minigun",
   "inventoryIcon" : "avaliminigun.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The primary Avali suppressive fire and support weapon.",
   "shortdescription" : "MG3 Hailstorm",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 1.0,
-	"speed" : 70,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier3/avalitier3pistol.gun
+++ b/items/guns/tier3/avalitier3pistol.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier3pistol",
   "inventoryIcon" : "avalipistol.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The basic Avali military grade sidearm.",
   "shortdescription" : "PD3 Frostbite",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -18,8 +18,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 2.4,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier3/avalitier3rifle.gun
+++ b/items/guns/tier3/avalitier3rifle.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier3rifle",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR3 Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier3/avalitier3riflebounce.gun
+++ b/items/guns/tier3/avalitier3riflebounce.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier3riflebounce",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR3-R Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgunbnc",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 60,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier3/avalitier3rifleexplosive.gun
+++ b/items/guns/tier3/avalitier3rifleexplosive.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier3rifleexplosive",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR3-HE Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgunexp",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier3/avalitier3shotgun.gun
+++ b/items/guns/tier3/avalitier3shotgun.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalishotgun.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "An avali shotgun!",
   "shortdescription" : "QRC Type-3",
   "image" : "avalishotgun.png",
@@ -21,8 +21,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 1.7,
+	"speed" : 150,
 	"life" : 3,
     "color" : [10, 255, 10]
   },

--- a/items/guns/tier3/avalitier3sniper.gun
+++ b/items/guns/tier3/avalitier3sniper.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalisniper.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "tooltipKind" : "bow",
   "weaponType" : "Bow",
   "description" : "An anti-materiel rifle more frequently used for hunting armoured vehicles than wildlife.",

--- a/items/guns/tier4/avalitier4minigun.gun
+++ b/items/guns/tier4/avalitier4minigun.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avaliminigun.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The primary Avali suppressive fire and support weapon.",
   "shortdescription" : "MG4 Hailstorm",
   "level" : 4,
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 1.0,
-	"speed" : 70,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier4/avalitier4pistol.gun
+++ b/items/guns/tier4/avalitier4pistol.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier4pistol",
   "inventoryIcon" : "avalipistol.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The basic Avali military grade sidearm.",
   "shortdescription" : "PD4 Frostbite",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -18,8 +18,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 2.4,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier4/avalitier4rifle.gun
+++ b/items/guns/tier4/avalitier4rifle.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier4rifle",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR4 Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier4/avalitier4riflebounce.gun
+++ b/items/guns/tier4/avalitier4riflebounce.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier4riflebounce",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR4-R Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgunbnc",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 60,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier4/avalitier4rifleexplosive.gun
+++ b/items/guns/tier4/avalitier4rifleexplosive.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier4rifleexplosive",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR4-HE Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -19,7 +19,7 @@
   "projectileType" : "railgunexp",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier4/avalitier4shotgun.gun
+++ b/items/guns/tier4/avalitier4shotgun.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalishotgun.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "An avali shotgun!",
   "shortdescription" : "QRC Type-4",
   "image" : "avalishotgun.png",
@@ -21,8 +21,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 1.7,
+	"speed" : 150,
 	"life" : 3,
     "color" : [10, 255, 10]
   },

--- a/items/guns/tier4/avalitier4sniper.gun
+++ b/items/guns/tier4/avalitier4sniper.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalisniper.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "tooltipKind" : "bow",
   "weaponType" : "Bow",
   "description" : "An anti-materiel rifle more frequently used for hunting armoured vehicles than wildlife.",

--- a/items/guns/tier5/avalitier5minigun.gun
+++ b/items/guns/tier5/avalitier5minigun.gun
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 1.0,
-	"speed" : 70,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier5/avalitier5pistol.gun
+++ b/items/guns/tier5/avalitier5pistol.gun
@@ -18,8 +18,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 2.4,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier5/avalitier5rifle.gun
+++ b/items/guns/tier5/avalitier5rifle.gun
@@ -19,7 +19,7 @@
   "projectileType" : "railgun1",
   "projectile" : {
 	"power" : 2.7,
-	"speed" : 90,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier5/avalitier5shotgun.gun
+++ b/items/guns/tier5/avalitier5shotgun.gun
@@ -21,8 +21,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 1.7,
+	"speed" : 150,
 	"life" : 3,
     "color" : [10, 255, 10]
   },

--- a/items/guns/tier6/avalitier6minigun.gun
+++ b/items/guns/tier6/avalitier6minigun.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier6minigun",
   "inventoryIcon" : "avaliminigun.png",
-  "rarity" : "rare",
+  "rarity" : "legendary",
   "description" : "The primary Avali suppressive fire and support weapon.",
   "shortdescription" : "MG6 Hailstorm",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],

--- a/items/guns/tier6/avalitier6pistol.gun
+++ b/items/guns/tier6/avalitier6pistol.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier6pistol",
   "inventoryIcon" : "avalipistol.png",
-  "rarity" : "rare",
+  "rarity" : "legendary",
   "description" : "The basic Avali military grade sidearm.",
   "shortdescription" : "PD6 Frostbite",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
@@ -18,8 +18,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 2.4,
+	"speed" : 150,
     "color" : [10, 255, 10]
   },
 

--- a/items/guns/tier6/avalitier6rifle.gun
+++ b/items/guns/tier6/avalitier6rifle.gun
@@ -1,7 +1,7 @@
 {
   "itemName" : "avalitier6rifle",
   "inventoryIcon" : "avalirifle.png",
-  "rarity" : "rare",
+  "rarity" : "legendary",
   "description" : "The standard Avali infantry weapon.",
   "shortdescription" : "AR6 Blizzard",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],

--- a/items/guns/tier6/avalitier6shotgun.gun
+++ b/items/guns/tier6/avalitier6shotgun.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalishotgun.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "legendary",
   "description" : "An avali shotgun!",
   "shortdescription" : "QRC Type-6",
   "image" : "avalishotgun.png",
@@ -21,8 +21,8 @@
 
   "projectileType" : "railgun1",
   "projectile" : {
-	"power" : 0.8,
-	"speed" : 70,
+	"power" : 1.7,
+	"speed" : 150,
 	"life" : 3,
     "color" : [10, 255, 10]
   },

--- a/items/guns/tier6/avalitier6sniper.gun
+++ b/items/guns/tier6/avalitier6sniper.gun
@@ -3,7 +3,7 @@
   "inventoryIcon" : "avalisniper.png",
   "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "legendary",
   "tooltipKind" : "bow",
   "weaponType" : "Bow",
   "description" : "An anti-materiel rifle more frequently used for hunting armoured vehicles than wildlife.",


### PR DESCRIPTION
Adjusts the Avali pistol and shotgun damage so that it's similar to
their vanilla counterparts of the same tier. Also adjusted the all the
gun's rarity so that it matches up to the vanilla rarity.