### PR TITLE
Ammo upgrades for tier 5 & 6 rifles

### DIFF
--- a/items/guns/tier5/avalitier5riflebounce.gun
+++ b/items/guns/tier5/avalitier5riflebounce.gun
@@ -1,0 +1,30 @@
+{
+  "itemName" : "avalitier5riflebounce",
+  "inventoryIcon" : "avalirifle.png",
+  "rarity" : "rare",
+  "description" : "The standard Avali infantry weapon.",
+  "shortdescription" : "AR5-R Blizzard",
+  "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
+  "maxStack" : 1,
+  "level" : 5,
+  "tooltipKind" : "gun",
+  "image" : "avalirifle.png",
+  "recoilTime" : 0.1,
+  "handPosition" : [0, 5],
+  "firePosition" : [13, 8],
+
+  "fireTime" : 0.3,
+  "twoHanded" : true,
+
+  "projectileType" : "railgunbnc",
+  "projectile" : {
+	"power" : 2.7,
+	"speed" : 150,
+    "color" : [10, 255, 10]
+  },
+
+  "muzzleEffect" : {
+    "animation" : "/animations/muzzleflash/electromuzzle/electromuzzle.animation",      
+    "fireSound" : [ { "file" : "/sfx/gun/plasma_ar1.wav" } ]
+  }
+}

--- a/items/guns/tier5/avalitier5rifleexplosive.gun
+++ b/items/guns/tier5/avalitier5rifleexplosive.gun
@@ -1,0 +1,30 @@
+{
+  "itemName" : "avalitier5rifleexplosive",
+  "inventoryIcon" : "avalirifle.png",
+  "rarity" : "rare",
+  "description" : "The standard Avali infantry weapon.",
+  "shortdescription" : "AR5-HE Blizzard",
+  "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
+  "maxStack" : 1,
+  "level" : 5,
+  "tooltipKind" : "gun",
+  "image" : "avalirifle.png",
+  "recoilTime" : 0.1,
+  "handPosition" : [0, 5],
+  "firePosition" : [13, 8],
+
+  "fireTime" : 0.3,
+  "twoHanded" : true,
+
+  "projectileType" : "railgunexp",
+  "projectile" : {
+	"power" : 2.7,
+	"speed" : 150,
+    "color" : [10, 255, 10]
+  },
+
+  "muzzleEffect" : {
+    "animation" : "/animations/muzzleflash/electromuzzle/electromuzzle.animation",    
+    "fireSound" : [ { "file" : "/sfx/gun/plasma_ar1.wav" } ]
+  }
+}

--- a/items/guns/tier6/avalitier6riflebounce.gun
+++ b/items/guns/tier6/avalitier6riflebounce.gun
@@ -1,0 +1,30 @@
+{
+  "itemName" : "avalitier6riflebounce",
+  "inventoryIcon" : "avalirifle.png",
+  "rarity" : "legendary",
+  "description" : "The standard Avali infantry weapon.",
+  "shortdescription" : "AR6-R Blizzard",
+  "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
+  "maxStack" : 1,
+  "level" : 6,
+  "tooltipKind" : "gun",
+  "image" : "avalirifle.png",
+  "recoilTime" : 0.1,
+  "handPosition" : [0, 5],
+  "firePosition" : [13, 8],
+
+  "fireTime" : 0.3,
+  "twoHanded" : true,
+
+  "projectileType" : "railgunbnc",
+  "projectile" : {
+	"power" : 2.7,
+	"speed" : 150,
+    "color" : [10, 255, 10]
+  },
+
+  "muzzleEffect" : {
+    "animation" : "/animations/muzzleflash/electromuzzle/electromuzzle.animation",      
+    "fireSound" : [ { "file" : "/sfx/gun/plasma_ar1.wav" } ]
+  }
+}

--- a/items/guns/tier6/avalitier6rifleexplosive.gun
+++ b/items/guns/tier6/avalitier6rifleexplosive.gun
@@ -1,0 +1,30 @@
+{
+  "itemName" : "avalitier6rifleexplosive",
+  "inventoryIcon" : "avalirifle.png",
+  "rarity" : "legendary",
+  "description" : "The standard Avali infantry weapon.",
+  "shortdescription" : "AR6-HE Blizzard",
+  "dropCollision" : [-8.0, -3.0, 8.0, 3.0],
+  "maxStack" : 1,
+  "level" : 6,
+  "tooltipKind" : "gun",
+  "image" : "avalirifle.png",
+  "recoilTime" : 0.1,
+  "handPosition" : [0, 5],
+  "firePosition" : [13, 8],
+
+  "fireTime" : 0.3,
+  "twoHanded" : true,
+
+  "projectileType" : "railgunexp",
+  "projectile" : {
+	"power" : 2.7,
+	"speed" : 150,
+    "color" : [10, 255, 10]
+  },
+
+  "muzzleEffect" : {
+    "animation" : "/animations/muzzleflash/electromuzzle/electromuzzle.animation",    
+    "fireSound" : [ { "file" : "/sfx/gun/plasma_ar1.wav" } ]
+  }
+}

--- a/recipes/crafting/bench/rifle/avalitier5riflebounce.recipe
+++ b/recipes/crafting/bench/rifle/avalitier5riflebounce.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "avalitoken", "count" : 1 },
+	{ "item" : "avalitier5rifle", "count" : 1 },
+	{ "item" : "money", "count" : 250}
+  ],
+  "output" : { "item" : "avalitier5riflebounce", "count" : 1 },
+  "groups" : [ "avalibench", "weapons", "all" ]
+}

--- a/recipes/crafting/bench/rifle/avalitier5rifleexplosive.recipe
+++ b/recipes/crafting/bench/rifle/avalitier5rifleexplosive.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "avalitoken", "count" : 1 },
+	{ "item" : "avalitier5rifle", "count" : 1 },
+	{ "item" : "money", "count" : 250}
+  ],
+  "output" : { "item" : "avalitier5rifleexplosive", "count" : 1 },
+  "groups" : [ "avalibench", "weapons", "all" ]
+}

--- a/recipes/crafting/bench/rifle/avalitier6riflebounce.recipe
+++ b/recipes/crafting/bench/rifle/avalitier6riflebounce.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "avalitoken", "count" : 1 },
+	{ "item" : "avalitier6rifle", "count" : 1 },
+	{ "item" : "money", "count" : 250}
+  ],
+  "output" : { "item" : "avalitier6riflebounce", "count" : 1 },
+  "groups" : [ "avalibench", "weapons", "all" ]
+}

--- a/recipes/crafting/bench/rifle/avalitier6rifleexplosive.recipe
+++ b/recipes/crafting/bench/rifle/avalitier6rifleexplosive.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "avalitoken", "count" : 1 },
+	{ "item" : "avalitier6rifle", "count" : 1 },
+	{ "item" : "money", "count" : 250}
+  ],
+  "output" : { "item" : "avalitier6rifleexplosive", "count" : 1 },
+  "groups" : [ "avalibench", "weapons", "all" ]
+}


### PR DESCRIPTION
You can now upgrade tier 5 & 6 rifles with bouncing and explosive
ammunition. Might re-adjust pixel cost by tier.