### PR TITLE
Fix for Naked Npcs

### DIFF
--- a/npcs/chefmerchant.npctype.patch
+++ b/npcs/chefmerchant.npctype.patch
@@ -1,8 +1,8 @@
 [
   { "op": "add",
-    "path": "/items",
-    "value": { "avali" : [
-      [0, [ {
+    "path": "/items/avali",
+    "value": 
+    [ [0, [ {
         "head": [
           "chefhead"
         ],
@@ -13,6 +13,6 @@
           { "name": "commondagger" }
         ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/doctormerchant.npctype.patch
+++ b/npcs/doctormerchant.npctype.patch
@@ -1,9 +1,9 @@
 [
   {
     "op": "add",
-    "path": "/items",
-    "value": { "avali" : [
-      [0, [ {
+    "path": "/items/avali",
+    "value": 
+    [ [0, [ {
         "head": [
           "avalidoctorhead"
         ],
@@ -17,6 +17,6 @@
           { "name": "commonplasmapistol" }
         ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/friendlyguard.npctype.patch
+++ b/npcs/friendlyguard.npctype.patch
@@ -1,9 +1,9 @@
 [
   { "op" : "add", "path" : "/scriptConfig/dialog/hail", "value" : "/dialog/avali.config:friendlyguard_hail" },
   { "op" : "add",
-    "path" : "/items",
-    "value" : { "avali" : [
-      [0, [ {
+    "path" : "/items/avali",
+    "value" : 
+    [ [0, [ {
         "head" : [ 
           { "name" : "avaliarmor1head", "data" : { "colorIndex" : [3] } },
           { "name" : "avaliarmor2head", "data" : { "colorIndex" : [3] } },
@@ -29,6 +29,6 @@
           { "name" : "avalitier4barrier" }
         ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/friendlyguard_accelerator.npctype.patch
+++ b/npcs/friendlyguard_accelerator.npctype.patch
@@ -1,8 +1,8 @@
 [
   { "op" : "add",
-    "path" : "/items",
-    "value" : { "avali" : [
-      [5, [ {
+    "path" : "/items/avali",
+    "value" : 
+    [ [5, [ {
         "head" : [ 
           { "name" : "avaliarmor4head", "data" : { "colorIndex" : [7] } },
           { "name" : "avaliarmor5head", "data" : { "colorIndex" : [7] } },
@@ -26,6 +26,6 @@
         "sheathedprimary": [ { "name": "avalitier1broadsword" } ],
         "alt": [ { "name": "avalitier6shotgun" } ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/friendlyguard_manipulator.npctype.patch
+++ b/npcs/friendlyguard_manipulator.npctype.patch
@@ -1,8 +1,8 @@
 [
   { "op" : "add",
-    "path" : "/items",
-    "value" : { "avali" : [
-      [5, [ {
+    "path" : "/items/avali",
+    "value" :
+    [ [5, [ {
         "head" : [ 
           { "name" : "avaliarmor4head", "data" : { "colorIndex" : [4] } },
           { "name" : "avaliarmor5head", "data" : { "colorIndex" : [4] } },
@@ -26,6 +26,6 @@
         "sheathedprimary": [ { "name": "avalitier1broadsword" } ],
         "alt": [ { "name": "avalitier6shotgun" } ]
         } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/friendlyminer.npctype.patch
+++ b/npcs/friendlyminer.npctype.patch
@@ -1,13 +1,13 @@
 [
   { "op" : "add",
-    "path" : "/items",
-    "value" : { "avali" : [
-      [0, [ {
+    "path" : "/items/avali",
+    "value" : 
+    [ [0, [ {
         "chest" : [ "avaliracial2chest" ],
         "legs" : [ "avaliracial2pants" ],
         "back" : [ "lanternstickback" ],
         "primary" : [ { "name" : "pickaxe" } ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/merchant.npctype.patch
+++ b/npcs/merchant.npctype.patch
@@ -1,9 +1,12 @@
 [
-  { "op" : "add", "path" : "/scriptConfig/merchant/categories/avali", "value" : [ "basicmerchant", "randomguns", "randomswords", "avaliguns", "avaliingredients", "musicalinstruments" ] },
+  { "op" : "add", 
+    "path" : "/scriptConfig/merchant/categories/avali", 
+    "value" : [ "basicmerchant", "randomguns", "randomswords", "avaliguns", "avaliingredients", "musicalinstruments" ] 
+  },
   { "op" : "add",
-    "path" : "/items",
-    "value" : { "avali" : [
-      [0, [ {
+    "path" : "/items/avali",
+    "value" : 
+    [ [0, [ {
         "chest" : [
           { "name" : "avaliset1chest", "parameters" : { "colorIndex" : [1,2,3,4,5,6,7,8,9,10,11] } },
           { "name" : "avaliset1bchest", "parameters" : { "colorIndex" : [1,2,3,4,5,6,7,8,9,10,11] } },
@@ -33,6 +36,6 @@
           { "name" : "avalihat4", "parameters" : { "colorIndex" : [1,2,3,4,5,6,7,8,9,10,11] } }
         ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/stimmerchant.npctype.patch
+++ b/npcs/stimmerchant.npctype.patch
@@ -1,7 +1,7 @@
 [
   { "op": "add",
-    "path": "/items",
-    "value": { "avali" : [
+    "path": "/items/avali",
+    "value": [
       [ 0, [ {
         "head": [
           { "name" : "avaliscientisthead", "parameters" : { "colorIndex" : [4] } }
@@ -13,6 +13,6 @@
           [ { "name": "commonplasmapistol" } ]
         ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/toolmerchant.npctype.patch
+++ b/npcs/toolmerchant.npctype.patch
@@ -1,7 +1,7 @@
 [
   { "op": "add",
-    "path": "/items",
-    "value": { "avali" : [
+    "path": "/items/avali",
+    "value": [
       [ 0, [ {
         "back": [
           "avalihat2back"
@@ -19,6 +19,6 @@
           [ { "name": "commondagger" } ]
         ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/villageguard.npctype.patch
+++ b/npcs/villageguard.npctype.patch
@@ -1,7 +1,7 @@
 [
   { "op": "add",
-    "path": "/items",
-    "value": { "avali" : [
+    "path": "/items/avali",
+    "value": [
       [ 0, [ {
         "head" : [ 
           { "name" : "avaliarmor1head", "data" : { "colorIndex" : [3] } },
@@ -65,6 +65,6 @@
         "sheathedprimary": [ { "name": "avalitier3shortsword" } ],
         "alt": [ { "name": "avalitier3barrier" } ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/villageguardcaptain.npctype.patch
+++ b/npcs/villageguardcaptain.npctype.patch
@@ -1,8 +1,8 @@
 [
   {
     "op": "add",
-    "path": "/items",
-    "value": { "avali" : [
+    "path": "/items/avali",
+    "value": [
       [ 0, [ {
 	    "head": [ { "name": "avaliarmor5head", "data" : { "colorIndex" : [3] } } ],
         "chest": [ { "name": "avaliguardtier1chest", "data" : { "colorIndex" : [3] } } ],
@@ -45,6 +45,6 @@
         "primary": [ { "name": "avalitier3minigin" } ],
         "sheathedprimary": [ { "name": "avalitier3spear" } ]
       } ] ]
-    ] }
+    ]
   }
 ]

--- a/npcs/villager.npctype.patch
+++ b/npcs/villager.npctype.patch
@@ -1,7 +1,7 @@
 [
   { "op" : "add",
-    "path" : "/items",
-    "value" : { "avali" : [
+    "path" : "/items/avali",
+    "value" : [
       [0, [ {
         "chest" : [
           { "name" : "avaliset1chest", "data" : { "colorIndex" : [1,2,3,4,5,6,7,8,9,10,11] } },
@@ -28,6 +28,6 @@
           { "name" : "avaliracial2head", "data" : { "colorIndex" : [1,2,3,4,5,6,7,8,9,10,11] } }
         ]
       } ] ]
-    ] }
+    ]
   }
 ]


### PR DESCRIPTION
Why this works: Old "path" and "value" creates {} in the entries for npc items, but there are none in the vanilla files, which causes Starbound to be unable to look up items for ANY npcs. changing the path to /items/avali lets Starbound sort out its own formatting.

Tested by: Found a planet with a nudist village. Save and exit the game. Altered my own files with these changes, then deleted planet file. On reloading the game/character, planet had regenerated with clothed npcs.

PS: I tried to maintain the formatting as much as possible