### PR TITLE
Possible fix for #120 and #119

### DIFF
--- a/dialog/guard.config.patch
+++ b/dialog/guard.config.patch
@@ -51,7 +51,7 @@
       ]
     }
   },
-  {  
+  /*{  
     "op":"add",
     "path":"/gunwarning1/avali",
     "value":{  
@@ -62,10 +62,10 @@
         "I don't care what your world's constitution says. No guns in public."
       ]
     }
-  },
+  },*/
   {  
     "op":"add",
-    "path":"/swordwarning2/avali",
+    "path":"/weaponwarning2/avali",
     "value":{  
       "default":[  
         "Second warning, stranger - put the weapon down.",
@@ -75,7 +75,7 @@
       ]
     }
   },
-  {  
+  /*{  
     "op":"add",
     "path":"/gunwarning2/avali",
     "value":{  
@@ -85,10 +85,10 @@
         "Holster it!"
       ]
     }
-  },
+  },*/
   {  
     "op":"add",
-    "path":"/swordwarning3/avali",
+    "path":"/weaponwarning3/avali",
     "value":{  
       "default":[  
         "You are sorely tempting me, friend.",
@@ -97,7 +97,7 @@
       ]
     }
   },
-  {  
+  /*{  
     "op":"add",
     "path":"/gunwarning3/avali",
     "value":{  
@@ -107,7 +107,7 @@
         "Don't make me come and take the gun and your LIFE!"
       ]
     }
-  },
+  },*/
   {  
     "op":"add",
     "path":"/weaponSheathed/avali",

--- a/items/active/weapons/ranged/tiered/pistol/avali/avalitier1pistol.activeitem
+++ b/items/active/weapons/ranged/tiered/pistol/avali/avalitier1pistol.activeitem
@@ -51,7 +51,7 @@
     "idle" : {
       "armRotation" : 0,
       "weaponRotation" : 0,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : true,
       "allowFlip" : true
@@ -60,7 +60,7 @@
       "duration" : 0,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false
@@ -69,7 +69,7 @@
       "duration" : 0.25,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false

--- a/items/active/weapons/ranged/tiered/pistol/avali/avalitier2pistol.activeitem
+++ b/items/active/weapons/ranged/tiered/pistol/avali/avalitier2pistol.activeitem
@@ -51,7 +51,7 @@
     "idle" : {
       "armRotation" : 0,
       "weaponRotation" : 0,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : true,
       "allowFlip" : true
@@ -60,7 +60,7 @@
       "duration" : 0,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false
@@ -69,7 +69,7 @@
       "duration" : 0.25,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false

--- a/items/active/weapons/ranged/tiered/pistol/avali/avalitier3pistol.activeitem
+++ b/items/active/weapons/ranged/tiered/pistol/avali/avalitier3pistol.activeitem
@@ -51,7 +51,7 @@
     "idle" : {
       "armRotation" : 0,
       "weaponRotation" : 0,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : true,
       "allowFlip" : true
@@ -60,7 +60,7 @@
       "duration" : 0,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false
@@ -69,7 +69,7 @@
       "duration" : 0.25,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false

--- a/items/active/weapons/ranged/tiered/pistol/avali/avalitier4pistol.activeitem
+++ b/items/active/weapons/ranged/tiered/pistol/avali/avalitier4pistol.activeitem
@@ -51,7 +51,7 @@
     "idle" : {
       "armRotation" : 0,
       "weaponRotation" : 0,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : true,
       "allowFlip" : true
@@ -60,7 +60,7 @@
       "duration" : 0,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false
@@ -69,7 +69,7 @@
       "duration" : 0.25,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false

--- a/items/active/weapons/ranged/tiered/pistol/avali/avalitier5pistol.activeitem
+++ b/items/active/weapons/ranged/tiered/pistol/avali/avalitier5pistol.activeitem
@@ -51,7 +51,7 @@
     "idle" : {
       "armRotation" : 0,
       "weaponRotation" : 0,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : true,
       "allowFlip" : true
@@ -60,7 +60,7 @@
       "duration" : 0,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false
@@ -69,7 +69,7 @@
       "duration" : 0.25,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false

--- a/items/active/weapons/ranged/tiered/pistol/avali/avalitier6pistol.activeitem
+++ b/items/active/weapons/ranged/tiered/pistol/avali/avalitier6pistol.activeitem
@@ -51,7 +51,7 @@
     "idle" : {
       "armRotation" : 0,
       "weaponRotation" : 0,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : true,
       "allowFlip" : true
@@ -60,7 +60,7 @@
       "duration" : 0,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false
@@ -69,7 +69,7 @@
       "duration" : 0.25,
       "armRotation" : 1,
       "weaponRotation" : 1,
-      "twoHanded" : true,
+      "twoHanded" : false,
 
       "allowRotate" : false,
       "allowFlip" : false

--- a/items/armors/avali/avali-guard_armor/avaliguardtier1.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier1.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 1.0
+      "baseMultiplier" : 1.0
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier2.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier2.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 1.5
+      "baseMultiplier" : 1.5
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier3.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier3.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 2.0
+      "baseMultiplier" : 2.0
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier4.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier4.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 2.5
+      "baseMultiplier" : 2.5
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier5a.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier5a.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 3.0
+      "baseMultiplier" : 3.0
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier5m.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier5m.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 4.0
+      "baseMultiplier" : 4.0
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier5s.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier5s.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 2.25
+      "baseMultiplier" : 2.25
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier6a.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier6a.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 3.5
+      "baseMultiplier" : 3.5
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier6m.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier6m.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 4.75
+      "baseMultiplier" : 4.75
     },
     {
       "stat" : "protection",

--- a/items/armors/avali/avali-guard_armor/avaliguardtier6s.chest
+++ b/items/armors/avali/avali-guard_armor/avaliguardtier6s.chest
@@ -22,7 +22,7 @@
   "statusEffects" : [
     {
       "stat" : "powerMultiplier",
-      "basePercentage" : 2.75
+      "baseMultiplier" : 2.75
     },
     {
       "stat" : "protection",


### PR DESCRIPTION
rename 'basePercentage' to 'baseMultiplier' in guard armor files

rename 'swordwarning' to 'weaponwarning' in guard.config.patch (dialog), and comment out now unused 'gunwarning's

someone may want to go through the dialog to make it better suit generic warnings, but this should work for now.

Also fixed pistol not rendering both arms when held in off hand