### PR TITLE
Added Missing Weapon Rack Recipes (Tech Bow)

### DIFF
--- a/recipes/crafting/lathe/B Objects/bow/AvaliBowDisplay01_tier1.recipe
+++ b/recipes/crafting/lathe/B Objects/bow/AvaliBowDisplay01_tier1.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "AvaliBow_t1", "count" : 1 },
+    { "item" : "aerogel", "count" : 1 }	
+  ],
+  "output" : { "item" : "AvaliBowDisplay01_tier1", "count" : 1 },
+  "groups" : [ "objects", "avalidisplayapparatus", "all" ]
+}

--- a/recipes/crafting/lathe/B Objects/bow/AvaliBowDisplay01_tier2.recipe
+++ b/recipes/crafting/lathe/B Objects/bow/AvaliBowDisplay01_tier2.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "AvaliBow_t2", "count" : 1 },
+    { "item" : "aerogel", "count" : 1 }	
+  ],
+  "output" : { "item" : "AvaliBowDisplay01_tier2", "count" : 1 },
+  "groups" : [ "objects", "avalidisplayapparatus", "all" ]
+}

--- a/recipes/crafting/lathe/B Objects/bow/AvaliBowDisplay01_tier3.recipe
+++ b/recipes/crafting/lathe/B Objects/bow/AvaliBowDisplay01_tier3.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "AvaliBow_t3", "count" : 1 },
+    { "item" : "aerogel", "count" : 1 }	
+  ],
+  "output" : { "item" : "AvaliBowDisplay01_tier3", "count" : 1 },
+  "groups" : [ "objects", "avalidisplayapparatus", "all" ]
+}

--- a/recipes/crafting/lathe/B Objects/bow/AvaliBowDisplay01_tier4.recipe
+++ b/recipes/crafting/lathe/B Objects/bow/AvaliBowDisplay01_tier4.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "AvaliBow_t4", "count" : 1 },
+    { "item" : "aerogel", "count" : 1 }	
+  ],
+  "output" : { "item" : "AvaliBowDisplay01_tier4", "count" : 1 },
+  "groups" : [ "objects", "avalidisplayapparatus", "all" ]
+}


### PR DESCRIPTION
It seems you forgot to add the actual recipes for my Avali Tech Bow's Weapon Racks when you merged it into the main mod.
I added them, and also tweaked them so they are now crafted at the Display Apparatus with the rest of the mounted weapon objects.