### PR TITLE
Fix Avali guards not using Avali clothing/weapons

### DIFF
--- a/npcs/friendlyguard.npctype.patch
+++ b/npcs/friendlyguard.npctype.patch
@@ -9,36 +9,5 @@
 	    "Huh, what, sorry. I was checking my messages."
 	  ]
 	}
-  },
-  { "op" : "add",
-    "path" : "/items/avali",
-    "value" : 
-    [ [0, [ {
-        "head" : [ 
-          { "name" : "avaliarmor1head", "data" : { "colorIndex" : [3] } },
-          { "name" : "avaliarmor2head", "data" : { "colorIndex" : [3] } },
-          { "name" : "avaliarmor3head", "data" : { "colorIndex" : [3] } }
-        ],
-        "chest": [ { "name": "avaliguardtier4chest", "data" : { "colorIndex" : [3] } } ],
-        "legs" : [
-          { "name" : "avaliarmor1pants", "data" : { "colorIndex" : [3] } },
-          { "name" : "avaliarmor2pants", "data" : { "colorIndex" : [3] } },
-          { "name" : "avaliarmor3pants", "data" : { "colorIndex" : [3] } }
-        ],
-        "primary" : [
-          { "name" : "avalitier4minigun" },
-          { "name" : "avalitier4rifle" },
-          { "name" : "avalitier4shotgun" },
-          { "name" : "avalitier4pistol" }
-        ],
-        "sheathedprimary" : [
-          { "name" : "avalitier4shortsword" }
-        ],
-        "alt" : [
-          { "name" : "avalitier4pistol" },
-          { "name" : "avalitier4barrier" }
-        ]
-      } ] ]
-    ]
   }
 ]

--- a/npcs/guard.npctype.patch
+++ b/npcs/guard.npctype.patch
@@ -1,0 +1,33 @@
+[
+  { "op" : "add",
+    "path" : "/items/avali",
+    "value" : 
+    [ [0, [ {
+        "head" : [ 
+          { "name" : "avaliarmor1head", "data" : { "colorIndex" : [3] } },
+          { "name" : "avaliarmor2head", "data" : { "colorIndex" : [3] } },
+          { "name" : "avaliarmor3head", "data" : { "colorIndex" : [3] } }
+        ],
+        "chest": [ { "name": "avaliguardtier4chest", "data" : { "colorIndex" : [3] } } ],
+        "legs" : [
+          { "name" : "avaliarmor1pants", "data" : { "colorIndex" : [3] } },
+          { "name" : "avaliarmor2pants", "data" : { "colorIndex" : [3] } },
+          { "name" : "avaliarmor3pants", "data" : { "colorIndex" : [3] } }
+        ],
+        "primary" : [
+          { "name" : "avalitier4minigun" },
+          { "name" : "avalitier4rifle" },
+          { "name" : "avalitier4shotgun" },
+          { "name" : "avalitier4pistol" }
+        ],
+        "sheathedprimary" : [
+          { "name" : "avalitier4shortsword" }
+        ],
+        "alt" : [
+          { "name" : "avalitier4pistol" },
+          { "name" : "avalitier4barrier" }
+        ]
+      } ] ]
+    ]
+  }
+]


### PR DESCRIPTION
Lets get this clear, before anybody goes and fucks this back up: there is no entry for items in friendlyguard.npctype (the base file)
There wasn't one the last time I fixed this, there isn't one now. Luthor614's last update throws an error in starbound.log and doesn't give the friendlyguard npcs racial clothing (the dialog part works fine though)

I have moved the patch for their clothing back to guard.npctype.patch You *could* make a new entry in friendlyguard.npctype and it would probably work, but I feel this leaves more options for npc entries down the road (anything that would be based off guard npcs wouldn't need the items copied over).