### PR TITLE
Fix Dragoon dialog?

### DIFF
--- a/dialog/dragoon.config
+++ b/dialog/dragoon.config
@@ -1,9 +1,11 @@
 {  
   "dragoon_attack": {
-    "default": [
+    "default" : {
+    	"default" : [
       "Taste the cold steel of my spear!",
       "You should not have come here...",
       "Death to the interlopper!"
-    ]
+      ]
+    }
   }
 }


### PR DESCRIPTION
encountered some dragoons on a planet and the game froze for a bit and spat out an error in the log. I think this fixes it.

At any rate, it now matches the default game dialog files structure which seems to be "speaker's race" : { "target's race" : [ "say this" ] }