### PR TITLE
Updating Techstation.object files

### DIFF
--- a/objects/ship/avalitechstation/avalitechstation.object
+++ b/objects/ship/avalitechstation/avalitechstation.object
@@ -52,14 +52,14 @@
   "dialog" : {
     "wakeUp" : [
       [ "Rebooting...", "/ai/portraits/avaliportrait.png:unique.1" ],
-      [ "I am S.A.I.L, your Ship-based Artificial Intelligence Lattice. I manage the maintainance of your ship.",       "/ai/portraits/avaliportrait.png:talk.0" ],
+      [ "I am S.A.I.L, your Ship-based Artificial Intelligence Lattice. I manage the maintainance of your ship.", "/ai/portraits/avaliportrait.png:talk.0" ],
       [ "I am also programmed to offer you information and advice.", "/ai/portraits/avaliportrait.png:talk.1" ],
       [ "Earth was attacked by an unknown force, and was subsequently annihilated.", "/ai/portraits/avaliportrait.png:talk.0" ],
       [ "The ship's navigation systems were damaged in our escape. Our location is currently unknown.", "/ai/portraits/avaliportrait.png:talk.1" ]
     ],
     "wakePlayer" : [
       [ "System is down, please reboot.", "/ai/portraits/avaliportrait.png:unique.1"],
-      [ "Please reboot the system.", "/ai/portraits/valiportrait.png:unique.1"],
+      [ "Please reboot the system.", "/ai/portraits/avaliportrait.png:unique.1"],
       [ "Reboot process remains uninitiated.", "/ai/portraits/avaliportrait.png:unique.1"],
       [ "To make use of your S.A.I.L please reboot.", "/ai/portraits/avaliportrait.png:unique.1" ],
       [ "Rebooting has shown to improve ship interaction satisfaction levels by 73%.", "/ai/portraits/avaliportrait.png:unique.1"],

--- a/objects/ship/avalitechstation/avalitechstation.object
+++ b/objects/ship/avalitechstation/avalitechstation.object
@@ -1,25 +1,27 @@
 {
   "objectName" : "avalitechstation",
   "colonyTags" : ["avali"],
-  "rarity" : "Common",
   "printable" : false,
+  "rarity" : "Common",
 
   "interactAction" : "OpenAiInterface",
 
   "category" : "decorative",
+
+  "description" : "Ship-based Artificial Intelligence Lattice, or S.A.I.L for short.",
+  "shortdescription" : "S.A.I.L",
+  "race" : "avali",
+
   "lightColor" : [102, 61, 61],
   "lightPosition" : [-1, 0],
 
-  "description" : "This tech station allows me to communicate with S.A.I.L and enable tech!",
-  "shortdescription" : "Tech Station",
-  "race" : "avali",
-
-  "apexDescription" : "A tech station. I can enable tech and talk to S.A.I.L through this.",
-  "avianDescription" : "I can use this station to enable tech and talk to S.A.I.L.",
-  "floranDescription" : "Floran use thisss for magiccc and talk to sshhip S.A.I.L!",
-  "glitchDescription" : "Informative. This tech station allows me to choose tech and talk to S.A.I.L.",
-  "humanDescription" : "A tech station. Allows me to communicate with S.A.I.L and enable tech!",
-  "hylotlDescription" : "This tech station enables tech and allows me to communicate with S.A.I.L.",
+  "apexDescription" : "I can talk to SAIL through this console.",
+  "avianDescription" : "I can use this station to talk to SAIL.",
+  "avaliDescription" : "This tech station allows me to communicate with SAIL.",
+  "floranDescription" : "Floran use thisss magic panel to talk to SAIL!",
+  "glitchDescription" : "Happy. This station allows me to talk to SAIL.",
+  "humanDescription" : "This station allows me to communicate with SAIL.",
+  "hylotlDescription" : "This console allows me to communicate with SAIL.",
   "novakidDescription" : "This here station let's me talk with SAIL.",
 
   "inventoryIcon" : "apexrecordplayericon.png",
@@ -35,8 +37,7 @@
 
     }
   ],
-  
-  "turnInQuests" : [ "gaterepair" ],
+
   "offeredQuests" : [ "gaterepair" ],
 
   "animation" : "/objects/ship/techstation.animation",
@@ -51,14 +52,14 @@
   "dialog" : {
     "wakeUp" : [
       [ "Rebooting...", "/ai/portraits/avaliportrait.png:unique.1" ],
-      [ "I am S.A.I.L, your Ship-based Artificial Intelligence Lattice. I manage the maintainance of your ship.", "/ai/portraits/avaliportrait.png:talk.0" ],
+      [ "I am S.A.I.L, your Ship-based Artificial Intelligence Lattice. I manage the maintainance of your ship.",       "/ai/portraits/avaliportrait.png:talk.0" ],
       [ "I am also programmed to offer you information and advice.", "/ai/portraits/avaliportrait.png:talk.1" ],
       [ "Earth was attacked by an unknown force, and was subsequently annihilated.", "/ai/portraits/avaliportrait.png:talk.0" ],
       [ "The ship's navigation systems were damaged in our escape. Our location is currently unknown.", "/ai/portraits/avaliportrait.png:talk.1" ]
     ],
     "wakePlayer" : [
       [ "System is down, please reboot.", "/ai/portraits/avaliportrait.png:unique.1"],
-      [ "Please reboot the system.", "/ai/portraits/avaliportrait.png:unique.1"],
+      [ "Please reboot the system.", "/ai/portraits/valiportrait.png:unique.1"],
       [ "Reboot process remains uninitiated.", "/ai/portraits/avaliportrait.png:unique.1"],
       [ "To make use of your S.A.I.L please reboot.", "/ai/portraits/avaliportrait.png:unique.1" ],
       [ "Rebooting has shown to improve ship interaction satisfaction levels by 73%.", "/ai/portraits/avaliportrait.png:unique.1"],

--- a/objects/ship/avalitechstationtier0/avalitechstationtier0.object
+++ b/objects/ship/avalitechstationtier0/avalitechstationtier0.object
@@ -28,7 +28,7 @@
   "hylotlDescription" : "This console will allow me to communicate with SAIL. I need to reboot it first.",
   "novakidDescription" : "Time to reboot this station so I can talk to SAIL.",
 
-  "inventoryIcon" : "aavalitechstationTier0icon.png",
+  "inventoryIcon" : "avalitechstationTier0icon.png",
   "orientations" : [
     {
       "imageLayers" : [ { "image" : "avalitechstationTier0.png:<color>.<frame>", "fullbright" : true }, { "image" : "avalitechstationlitTier0.png:<color>.<frame>" } ],

--- a/objects/ship/avalitechstationtier0/avalitechstationtier0.object
+++ b/objects/ship/avalitechstationtier0/avalitechstationtier0.object
@@ -12,7 +12,7 @@
   "shortdescription" : "S.A.I.L",
   "race" : "avali",
   
-  "lightColor" : [77, 111, 128],
+  "lightColor" : [128, 77, 77],
   "lightPosition" : [-1, 0],
   
   "flickerDistance" : 1.0,

--- a/objects/ship/avalitechstationtier0/avalitechstationtier0.object
+++ b/objects/ship/avalitechstationtier0/avalitechstationtier0.object
@@ -1,32 +1,34 @@
 {
   "objectName" : "avalitechstationTier0",
   "colonyTags" : ["avali"],
-  "rarity" : "Common",
   "printable" : false,
+  "rarity" : "Common",
 
   "interactAction" : "OpenAiInterface",
 
   "category" : "decorative",
-  "lightColor" : [128, 77, 77],
+
+  "description" : "Ship-based Artificial Intelligence Lattice, or S.A.I.L for short.",
+  "shortdescription" : "S.A.I.L",
+  "race" : "avali",
+  
+  "lightColor" : [77, 111, 128],
   "lightPosition" : [-1, 0],
   
   "flickerDistance" : 1.0,
   "flickerStrength" : 0.05,
   "flickerTiming" : 8,
 
-  "description" : "A tech station. For creating awesome tech!",
-  "shortdescription" : "Tech Station",
-  "race" : "avali",
-
-  "apexDescription" : "A tech station. Useful.",
-  "avianDescription" : "I can use this tech station to make things, when it's not off.",
-  "floranDescription" : "Floran create magic bang bangs!",
-  "glitchDescription" : "Admiration. An extremely advanced tech station.",
-  "humanDescription" : "A tech station. I can create awesome stuff here!",
-  "hylotlDescription" : "This tech station looks decent enough.",
+  "apexDescription" : "When it's working, I can talk to SAIL through this console.",
+  "avianDescription" : "Rebooting this station should enable me to talk to SAIL.",
+  "avaliDescription" : "This tech station would allow me to communicate with SAIL, if it were rebooted.",
+  "floranDescription" : "Floran fix thisss panel to wake ship up!",
+  "glitchDescription" : "Distressed. I first need to reboot this station to communicate with SAIL.",
+  "humanDescription" : "If I can reboot this station SAIL should come back online!",
+  "hylotlDescription" : "This console will allow me to communicate with SAIL. I need to reboot it first.",
   "novakidDescription" : "Time to reboot this station so I can talk to SAIL.",
 
-  "inventoryIcon" : "avalitechstationTier0icon.png",
+  "inventoryIcon" : "aavalitechstationTier0icon.png",
   "orientations" : [
     {
       "imageLayers" : [ { "image" : "avalitechstationTier0.png:<color>.<frame>", "fullbright" : true }, { "image" : "avalitechstationlitTier0.png:<color>.<frame>" } ],


### PR DESCRIPTION
Updated the tech station .object files to match the vanilla stations. Originally thought doing so would fix the bug with the SAIL’s wakeUp dialog being skipped, but further testing had the bug still occurring, and if it isn’t the .object file causing it I’m not sure what is, so this is just a standard update then.