### PR TITLE
blockkey.config patch

### DIFF
--- a/ships/avali/blockkey.config
+++ b/ships/avali/blockkey.config
@@ -120,8 +120,9 @@
     {
       "value" : [255, 102, 0, 255],
       "foregroundBlock" : false,
-      "backgroundBlock" : true,
-      "object" : "avalishipdoor"
+      "backgroundBlock" : false,
+      "object" : "avalishipdoor",
+      "objectResidual" : true
     },
     
     {


### PR DESCRIPTION
changes made to prevent the Avali door from disappearing on upgrade to Tier 4 or higher.