### PR TITLE
Avali Tile Recipes Adjustments

### DIFF
--- a/recipes/crafting/lathe/B Objects/avalistairs.recipe
+++ b/recipes/crafting/lathe/B Objects/avalistairs.recipe
@@ -1,9 +1,0 @@
-{
-  "input" : [
-    { "item" : "aerogel", "count" : 1 },
-    { "item" : "mediummetal", "count" : 1 }
-  ],
-  "output" : { "item" : "avalistairs", "count" : 1 },
-  "duration" : 0.1,
-  "groups" : [ "materials", "avalilathe", "all" ]
-}

--- a/recipes/crafting/lathe/C Tiles/avaliaeroponics.recipe
+++ b/recipes/crafting/lathe/C Tiles/avaliaeroponics.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-    { "item" : "aerogel", "count" : 1 }
+    { "item" : "aerogel", "count" : 5 }
   ],
-  "output" : { "item" : "avaliaeroponics", "count" : 1 },
+  "output" : { "item" : "avaliaeroponics", "count" : 5 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avalidarkmetal.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalidarkmetal.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-    { "item" : "ironblock", "count" : 1 }
+    { "item" : "ironblock", "count" : 5 }
   ],
-  "output" : { "item" : "avalidarkmetal", "count" : 1 },
+  "output" : { "item" : "avalidarkmetal", "count" : 5 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avalidarkmetal2.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalidarkmetal2.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-    { "item" : "ironblock", "count" : 1 }
+    { "item" : "ironblock", "count" : 5 }
   ],
-  "output" : { "item" : "avalidarkmetal2", "count" : 1 },
+  "output" : { "item" : "avalidarkmetal2", "count" : 5 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avalidarkmetal3.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalidarkmetal3.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-    { "item" : "ironblock", "count" : 1 }
+    { "item" : "ironblock", "count" : 5 }
   ],
-  "output" : { "item" : "avalidarkmetal3", "count" : 1 },
+  "output" : { "item" : "avalidarkmetal3", "count" : 5 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avaliglass.recipe
+++ b/recipes/crafting/lathe/C Tiles/avaliglass.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-    { "item" : "aerogel", "count" : 1 }
+    { "item" : "aerogel", "count" : 5 }
   ],
-  "output" : { "item" : "avaliglass", "count" : 1 },
+  "output" : { "item" : "avaliglass", "count" : 10 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avalihexagons.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalihexagons.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-    { "item" : "graphene", "count" : 1 }
+    { "item" : "graphene", "count" : 10 }
   ],
-  "output" : { "item" : "avalihexagons1", "count" : 1 },
+  "output" : { "item" : "avalihexagons1", "count" : 20 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avalipaneling.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalipaneling.recipe
@@ -1,9 +1,9 @@
 {
   "input" : [
-    { "item" : "mediummetal", "count" : 1 },
-  { "item" : "graphene", "count" : 1 }
+    { "item" : "mediummetal", "count" : 5 },
+  { "item" : "graphene", "count" : 5 }
   ],
-  "output" : { "item" : "avalipaneling", "count" : 1 },
+  "output" : { "item" : "avalipaneling", "count" : 10 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avalipaneling2.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalipaneling2.recipe
@@ -1,9 +1,9 @@
 {
   "input" : [
-    { "item" : "mediummetal", "count" : 1 },
-  { "item" : "graphene", "count" : 1 }
+    { "item" : "mediummetal", "count" : 5 },
+  { "item" : "graphene", "count" : 5 }
   ],
-  "output" : { "item" : "avalipaneling2", "count" : 1 },
+  "output" : { "item" : "avalipaneling2", "count" : 10 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avaliplain.recipe
+++ b/recipes/crafting/lathe/C Tiles/avaliplain.recipe
@@ -1,9 +1,9 @@
 {
   "input" : [
-    { "item" : "mediummetal", "count" : 1 },
-  { "item" : "graphene", "count" : 1 }
+    { "item" : "mediummetal", "count" : 5 },
+  { "item" : "graphene", "count" : 5 }
   ],
-  "output" : { "item" : "avaliplain", "count" : 1 },
+  "output" : { "item" : "avaliplain", "count" : 10 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avaliplatform.recipe
+++ b/recipes/crafting/lathe/C Tiles/avaliplatform.recipe
@@ -1,9 +1,9 @@
 {
   "input" : [
-    { "item" : "aerogel", "count" : 1 },
-    { "item" : "mediummetal", "count" : 1 }
+    { "item" : "aerogel", "count" : 5 },
+    { "item" : "mediummetal", "count" : 5 }
   ],
-  "output" : { "item" : "avaliplatform", "count" : 1 },
+  "output" : { "item" : "avaliplatform", "count" : 10 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avalistairs.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalistairs.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "aerogel", "count" : 5 },
+    { "item" : "mediummetal", "count" : 5 }
+  ],
+  "output" : { "item" : "avalistairs", "count" : 10 },  
+  "duration" : 0.1,
+  "groups" : [ "materials", "avalilathe", "all" ]
+}

--- a/recipes/crafting/lathe/C Tiles/avalitechpanel.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalitechpanel.recipe
@@ -1,9 +1,9 @@
 {
   "input" : [
-    { "item" : "mediummetal", "count" : 1 },
-	{ "item" : "graphene", "count" : 1 }
+    { "item" : "mediummetal", "count" : 5 },
+	{ "item" : "graphene", "count" : 5 }
   ],
-  "output" : { "item" : "avalitechpanel", "count" : 1 },
+  "output" : { "item" : "avalitechpanel", "count" : 10 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }

--- a/recipes/crafting/lathe/C Tiles/avalitiles.recipe
+++ b/recipes/crafting/lathe/C Tiles/avalitiles.recipe
@@ -1,9 +1,9 @@
 {
   "input" : [
-    { "item" : "mediummetal", "count" : 1 },
-	{ "item" : "graphene", "count" : 1 }
+    { "item" : "mediummetal", "count" : 5 },
+	{ "item" : "graphene", "count" : 5 }
   ],
-  "output" : { "item" : "avalitiles", "count" : 1 },
+  "output" : { "item" : "avalitiles", "count" : 10 },
   "groups" : [ "materials", "avalilathe", "all" ],
   "duration" : 0.1
 }


### PR DESCRIPTION
Changes most tile recipes to be done in batches (input and output x5)
Also doubles the output of tile recipes with 2 ingredients (seems in
line with the large increase in vanilla tile recipes. Also I like big
bases)

On a side note, why was the stairs platform recipe in Objects instead of Tiles?
