### PR TITLE
Fixes "invisible blocks", more recipe tweaks

### DIFF
--- a/objects/avaligeneric/racks/frameddagger/avalitier10daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/avalitier10daggerdisplay.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier10daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [2, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/frameddagger/avalitier1daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/avalitier1daggerdisplay.object
@@ -20,11 +20,11 @@
   "orientations" : [
     {
       "dualImage" : "avalitier1daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [0, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "background" ]
 
     }

--- a/objects/avaligeneric/racks/frameddagger/avalitier2daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/avalitier2daggerdisplay.object
@@ -20,11 +20,11 @@
   "orientations" : [
     {
       "dualImage" : "avalitier2daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [0, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "background" ]
 
     }

--- a/objects/avaligeneric/racks/frameddagger/avalitier3daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/avalitier3daggerdisplay.object
@@ -20,11 +20,11 @@
   "orientations" : [
     {
       "dualImage" : "avalitier3daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [0, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "background" ]
 
     }

--- a/objects/avaligeneric/racks/frameddagger/avalitier4daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/avalitier4daggerdisplay.object
@@ -20,11 +20,11 @@
   "orientations" : [
     {
       "dualImage" : "avalitier4daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [0, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "background" ]
 
     }

--- a/objects/avaligeneric/racks/frameddagger/avalitier5daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/avalitier5daggerdisplay.object
@@ -20,11 +20,11 @@
   "orientations" : [
     {
       "dualImage" : "avalitier5daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [0, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "background" ]
 
     }

--- a/objects/avaligeneric/racks/frameddagger/avalitier6daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/avalitier6daggerdisplay.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier6daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [2, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/frameddagger/avalitier8daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/avalitier8daggerdisplay.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier8daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [2, 1],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/frameddagger/unused/avalitier7daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/unused/avalitier7daggerdisplay.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier7daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [2, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/frameddagger/unused/avalitier9daggerdisplay.object
+++ b/objects/avaligeneric/racks/frameddagger/unused/avalitier9daggerdisplay.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier9daggerdisplay.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [2, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/hammer/avalitier10hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/avalitier10hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/avalitier1hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/avalitier1hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/avalitier2hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/avalitier2hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/avalitier3hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/avalitier3hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/avalitier4hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/avalitier4hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/avalitier8hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/avalitier8hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/unused/avalitier5hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/unused/avalitier5hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/unused/avalitier6hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/unused/avalitier6hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/unused/avalitier7hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/unused/avalitier7hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hammer/unused/avalitier9hammerdisplay.object
+++ b/objects/avaligeneric/racks/hammer/unused/avalitier9hammerdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/hangingdagger/avalitier10daggerhanging.object
+++ b/objects/avaligeneric/racks/hangingdagger/avalitier10daggerhanging.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier10daggerhanging.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [2, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/hangingdagger/avalitier5daggerhanging.object
+++ b/objects/avaligeneric/racks/hangingdagger/avalitier5daggerhanging.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier5daggerhanging.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [0, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/hangingdagger/avalitier6daggerhanging.object
+++ b/objects/avaligeneric/racks/hangingdagger/avalitier6daggerhanging.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier6daggerhanging.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [2, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/hangingdagger/avalitier8daggerhanging.object
+++ b/objects/avaligeneric/racks/hangingdagger/avalitier8daggerhanging.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier8daggerhanging.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [2, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/hangingdagger/unused/avalitier7daggerhanging.object
+++ b/objects/avaligeneric/racks/hangingdagger/unused/avalitier7daggerhanging.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier7daggerhanging.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [-1, 2],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/hangingdagger/unused/avalitier9daggerhanging.object
+++ b/objects/avaligeneric/racks/hangingdagger/unused/avalitier9daggerhanging.object
@@ -20,7 +20,7 @@
   "orientations" : [
     {
       "dualImage" : "avalitier9daggerhanging.png:<color>",
-      "imagePosition" : [0, 0],
+      "imagePosition" : [-2, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/avaligeneric/racks/pilum/avalitier1pilumdisplay.object
+++ b/objects/avaligeneric/racks/pilum/avalitier1pilumdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/pilum/avalitier2pilumdisplay.object
+++ b/objects/avaligeneric/racks/pilum/avalitier2pilumdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/objects/avaligeneric/racks/pilum/avalitier3pilumdisplay.object
+++ b/objects/avaligeneric/racks/pilum/avalitier3pilumdisplay.object
@@ -25,7 +25,7 @@
       "frames" : 1,
       "animationCycle" : 0.5,
 
-      "spaceScan" : 0.1,
+      "spaceScan" : 0.2,
       "anchors" : [ "bottom" ]
 
     }

--- a/recipes/crafting/lathe/B Objects/avaliterminal3.recipe
+++ b/recipes/crafting/lathe/B Objects/avaliterminal3.recipe
@@ -6,5 +6,5 @@
   ],
   "output" : { "item" : "avaliterminal3", "count" : 1 },
   "duration" : 0.1,
-  "groups" : [ "wirings", "avalilathe", "all" ]
+  "groups" : [ "storage", "avalilathe", "all" ]
 }

--- a/recipes/crafting/lathe/D Feedstocks/aerogel.recipe
+++ b/recipes/crafting/lathe/D Feedstocks/aerogel.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-    { "item" : "graphene", "count" : 1 }
+    { "item" : "graphene", "count" : 5 }
   ],
-  "output" : { "item" : "aerogel", "count" : 1 },
+  "output" : { "item" : "aerogel", "count" : 5 },
   "duration" : 0.1,
   "groups" : [ "ingredients", "avalilathe", "all"]
 }


### PR DESCRIPTION
Moved the avali terminal 3 to storage, which is what it is. should fix #298 
Made aerogel be crafted in batchs of 5 (5 graphene to 5 aerogel)

Fixed the invisible blocks that many displays seem to have. Also,
centered up some of the displays so its more obvious what they occupy. should fix #209 